### PR TITLE
[Submit] Include PR body in 'create'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ const API_ROUTES = asRouteTree({
             head: t.string,
             base: t.string,
             title: t.string,
+            body: t.optional(t.string),
           }),
           t.shape({
             action: t.literals(["update"] as const),


### PR DESCRIPTION
Passing the body of the PR up to the server.

Only adding an optional param for body (so that it's backwards compatible) to the PR creation path for now.

We'll likely want this for the PR update path in the future, but that can happen in its own backwards-compatible change and there's stuff to iron out before we get there (namely what would the editing experience look like in that case).